### PR TITLE
Add C interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DEFINES := -D_GNU_SOURCE=1 -D_POSIX_C_SOURCE=20181101 -D__USE_XOPEN=1 -DAPP_VERS
 INCLUDE := -I include -I cxxopts/include
 CXXFLAGS += -g -O3 -std=c++14 -Wall $(INCLUDE) $(DEFINES)
 CFLAGS += -g -O3 -Wall -Wshadow $(INCLUDE) $(DEFINES)
-LIBS := -ldl -pthread -lseccomp
+LIBS := -pthread -lseccomp
 
 # Source files and objects to build.
 src = $(wildcard src/*.cpp)

--- a/include/dettrace.hpp
+++ b/include/dettrace.hpp
@@ -1,0 +1,122 @@
+#ifndef DETTRACE_H
+#define DETTRACE_H
+
+#include <time.h>
+
+extern "C" {
+
+struct SyscallState {
+  bool noop;
+};
+
+typedef long (*SysEnter)(
+    void* data,
+    struct SyscallState* s,
+    int pid,
+    int tid,
+    int syscallno,
+    unsigned long arg0,
+    unsigned long arg1,
+    unsigned long arg2,
+    unsigned long arg3,
+    unsigned long arg4,
+    unsigned long arg5);
+
+typedef long (*SysExit)(
+    void* data,
+    struct SyscallState* s,
+    int pid,
+    int tid,
+    int syscallno,
+    unsigned long retval,
+    unsigned long arg0,
+    unsigned long arg1,
+    unsigned long arg2,
+    unsigned long arg3,
+    unsigned long arg4,
+    unsigned long arg5);
+
+typedef struct {
+  // Path to the chroot directory.
+  const char* chroot_dir;
+
+  bool with_devrand_overrides;
+  bool with_proc_overrides;
+  bool with_etc_overrides;
+} MountOptions;
+
+/**
+ * Options for Dettrace.
+ */
+typedef struct {
+  // Name of the program.
+  const char* program;
+
+  // List of arguments. The first argument should be a pointer to the program
+  // name. As expected by execvpe, this needs to be a NULL terminated array.
+  char* const* argv;
+
+  // The environment variables. As expected by execvpe, this needs to be a NULL
+  // terminated array.
+  char* const* envs;
+
+  // Working directory to chdir() into before the execvpe().
+  const char* workdir;
+
+  // Flags to use to when clone()ing.
+  int clone_ns_flags;
+
+  // The timeout in seconds before the tracee is killed. Set to 0 for no
+  // timeout (i.e., indefinite).
+  unsigned int timeout;
+
+  // Callback function to run before each time a syscall is made. If NULL, the
+  // callback is not executed.
+  SysEnter sys_enter;
+
+  // Callback function to run after each time a syscall is made. If NULL, the
+  // callback is not executed.
+  SysExit sys_exit;
+
+  // Pointer to some data that will be passed to each sys_enter and sys_exit
+  // call.
+  void* user_data;
+
+  // The beginning of time we will use.
+  time_t epoch;
+
+  // The number of microseconds to increment the clock.
+  unsigned long clock_step;
+
+  // The seed to use for /dev/[u]random and other random-related system calls.
+  unsigned short prng_seed;
+
+  // Whether or not to allow networking.
+  bool allow_network;
+
+  // Whether or not ASLR should be on or off.
+  bool with_aslr;
+
+  bool convert_uids;
+
+  MountOptions mount;
+
+  // Logging options
+  int debug_level;
+  bool use_color;
+  bool print_statistics;
+  const char* log_file;
+} TraceOptions;
+
+/**
+ * Spawns the tracee process. If no mount options are provided, we assume that
+ * the container has already been created and we are chrooted.
+ *
+ * If the return value is -1, an error has occured attempting to spawn
+ * the process. Otherwise, the pid of the child is returned.
+ */
+pid_t dettrace(const TraceOptions* options);
+
+} // extern "C"
+
+#endif // DETTRACE_H

--- a/include/devrand.hpp
+++ b/include/devrand.hpp
@@ -1,0 +1,28 @@
+#ifndef DEVRAND_H
+#define DEVRAND_H
+
+#include <string>
+
+#include <pthread.h>
+
+class RandThread {
+private:
+  std::string fifo;
+  unsigned short seed;
+
+  pthread_t thread;
+  pthread_mutex_t thread_mutex;
+  pthread_cond_t thread_ready;
+
+  static void* runThread(void* data);
+
+public:
+  RandThread(const std::string& fifo, unsigned short seed);
+
+  // Shuts down the thread.
+  void shutdown();
+
+  const std::string& path() const { return fifo; }
+};
+
+#endif // DEVRAND_H

--- a/include/rnr_loader.hpp
+++ b/include/rnr_loader.hpp
@@ -1,54 +1,24 @@
 #ifndef _MY_RNR_LOADER_H
 #define _MY_RNR_LOADER_H
 
+#include "dettrace.hpp"
 #include "globalState.hpp"
 #include "scheduler.hpp"
 #include "state.hpp"
 
-struct SyscallState {
-  bool noop;
-};
-
-struct ProcessState {};
-
-extern "C" {
-struct rnr_loader {
-  long (*rnr_sysenter)(
-      struct SyscallState* s,
-      int pid,
-      int tid,
-      int syscallno,
-      unsigned long arg0,
-      unsigned long arg1,
-      unsigned long arg2,
-      unsigned long arg3,
-      unsigned long arg4,
-      unsigned long arg5);
-  long (*rnr_sysexit)(
-      struct SyscallState* s,
-      int pid,
-      int tid,
-      int syscallno,
-      unsigned long retval,
-      unsigned long arg0,
-      unsigned long arg1,
-      unsigned long arg2,
-      unsigned long arg3,
-      unsigned long arg4,
-      unsigned long arg5);
-};
-}
-
 class rnr {
 public:
-  static void loadRnr(const string& dso);
   static bool callPreHook(
+      void* user_data,
+      SysEnter sysenter,
       int syscallNumber,
       globalState& gs,
       state& s,
       ptracer& t,
       scheduler& sched);
   static void callPostHook(
+      void* user_data,
+      SysExit sysexit,
       int syscallNumber,
       globalState& gs,
       state& s,

--- a/include/vdso.hpp
+++ b/include/vdso.hpp
@@ -27,7 +27,15 @@ std::ostream& operator<<(std::ostream& out, ProcMapEntry const& e);
 std::vector<ProcMapEntry> parseProcMapEntries(pid_t pid);
 std::map<std::string, std::basic_string<unsigned char>> vdsoGetCandidateData(
     void);
-std::map<std::string, std::tuple<unsigned long, unsigned long, unsigned long>>
-vdsoGetSymbols(pid_t pid);
+
+struct VDSOSymbol {
+  unsigned long offset;
+  unsigned long size;
+  unsigned long alignment;
+};
+
+using VDSOSymbols = std::map<std::string, VDSOSymbol>;
+
+VDSOSymbols vdsoGetSymbols(pid_t pid);
 
 #endif

--- a/src/dettrace.cpp
+++ b/src/dettrace.cpp
@@ -1,0 +1,520 @@
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/mount.h>
+#include <sys/personality.h>
+#include <sys/prctl.h>
+#include <sys/ptrace.h>
+#include <sys/reg.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <sys/user.h>
+#include <sys/vfs.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "dettrace.hpp"
+#include "devrand.hpp"
+#include "execution.hpp"
+#include "logicalclock.hpp"
+#include "seccomp.hpp"
+#include "tempfile.hpp"
+#include "util.hpp"
+#include "vdso.hpp"
+
+struct CloneArgs {
+  const TraceOptions* opts;
+  VDSOSymbols vdso_syms;
+};
+
+static pid_t _dettrace(const TraceOptions* opts);
+static int _dettrace_child(const CloneArgs* opts);
+static int runTracee(
+    const TraceOptions& opts,
+    const std::string& devrandFifoPath,
+    const std::string& devUrandFifoPath);
+
+// See user_namespaces(7)
+static void update_map(char* mapping, char* map_file);
+static void proc_setgroups_write(pid_t pid, const char* str);
+
+extern "C" pid_t dettrace(const TraceOptions* opts) {
+  try {
+    return _dettrace(opts);
+  } catch (std::runtime_error e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    return -1;
+  } catch (...) {
+    std::cerr << "Error: Unknown exception occurred\n";
+    return -1;
+  }
+
+  return -1;
+}
+
+static execution* globalExeObject = nullptr;
+
+void sigalrmHandler(int _) {
+  assert(nullptr != globalExeObject);
+  globalExeObject->killAllProcesses();
+  // TODO: print out message about timeout expiring
+  runtimeError("dettrace timeout expired\n");
+}
+
+/**
+ * Use stat to check if file/directory exists to mount.
+ * @return boolean if file exists
+ */
+static bool fileExists(const std::string& file) {
+  struct stat sb;
+
+  return (stat(file.c_str(), &sb) == 0);
+}
+
+/**
+ * Wrapper around mount with strings.
+ */
+static void mountDir(const std::string& source, const std::string& target) {
+  /* Check if source path exists*/
+  if (!fileExists(source)) {
+    runtimeError(
+        "Trying to mount " + source + " => " + target +
+        ". Source file does not exist.\n");
+  }
+
+  /* Check if target path exists*/
+  if (!fileExists(target)) {
+    runtimeError(
+        "Trying to mount " + source + " => " + target +
+        ". Target file does not exist.\n");
+  }
+
+  // TODO: Marking it as private here shouldn't be necessary since we already
+  // unshared the entire namespace as private? Notice that we want a bind mount,
+  // so MS_BIND is necessary. MS_REC is also necessary to properly work when
+  // mounting dirs that are themselves bind mounts, otherwise you will get an
+  // error EINVAL as per `man 2 mount`: EINVAL In an unprivileged mount
+  // namespace (i.e., a mount namespace owned by  a  user
+  //             namespace  that  was created by an unprivileged user), a bind
+  //             mount operation (MS_BIND)  was  attempted  without  specifying
+  //             (MS_REC),  which  would  have revealed the filesystem tree
+  //             underneath one of the submounts of the directory being bound.
+
+  // Note this line causes spurious false positives when running under valgrind.
+  // It's okay that these areguments are nullptr.
+  doWithCheck(
+      mount(
+          source.c_str(), target.c_str(), nullptr,
+          MS_BIND | MS_PRIVATE | MS_REC, nullptr),
+      "Unable to bind mount: " + source + " to " + target);
+}
+
+/**
+ * Creates a blank file with sensible permissions.
+ */
+static void createFileIfNotExist(const std::string& path) {
+  if (fileExists(path)) {
+    return;
+  }
+
+  int fd;
+  doWithCheck(
+      (fd = open(path.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IRGRP | S_IROTH)),
+      "Unable to create file: " + path);
+  if (fd >= 0) close(fd);
+
+  return;
+}
+
+static pid_t _dettrace(const TraceOptions* opts) {
+  if (!opts) {
+    return -1;
+  }
+
+  // our own user namespace. Other namespace commands require CAP_SYS_ADMIN to
+  // work. Namespaces must must be done before fork. As changes don't apply
+  // until after fork, to all child processes.
+  const int STACK_SIZE(1024 * 1024);
+  static char child_stack[STACK_SIZE]; /* Space for child's stack */
+
+  doWithCheck(
+      prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0),
+      "Pre-clone prctl error: setting no new privs");
+
+  auto clone_args = CloneArgs{
+      opts,
+      vdsoGetSymbols(getpid()),
+  };
+
+  if (clone_args.vdso_syms.size() < 4) {
+    runtimeError(
+        "VDSO symbol map has only " + to_string(clone_args.vdso_syms.size()) +
+        ", expect at least 4!");
+  }
+
+  pid_t child = clone(
+      (int (*)(void*))_dettrace_child, child_stack + STACK_SIZE,
+      opts->clone_ns_flags | SIGCHLD, (void*)&clone_args);
+  if (child == -1) {
+    std::string reason = strerror(errno);
+    std::cerr << "clone failed:\n  " + reason << std::endl;
+    return -1;
+  }
+
+  // This is modified code from user_namespaces(7)
+  // see https://lwn.net/Articles/532593/
+  /* Update the UID and GID maps for children in their namespace, notice we do
+     not live in that namespace. We use clone instead of unshare to avoid moving
+     us into to the namespace. This allows us, in the future, to extend the
+     mappings to other uids when running as root (not currently implemented, but
+     notice this cannot be done when using unshare.)*/
+  if ((opts->clone_ns_flags & CLONE_NEWUSER) == CLONE_NEWUSER) {
+    char map_path[PATH_MAX];
+    const int MAP_BUF_SIZE = 100;
+    char map_buf[MAP_BUF_SIZE];
+    char* uid_map;
+    char* gid_map;
+
+    uid_t uid = getuid();
+    gid_t gid = getgid();
+
+    // Set up container to hostOS UID and GID mappings
+    snprintf(map_path, PATH_MAX, "/proc/%d/uid_map", child);
+    snprintf(map_buf, MAP_BUF_SIZE, "0 %ld 1", (long)uid);
+    uid_map = map_buf;
+    update_map(uid_map, map_path);
+
+    // Set GID Map
+    string deny = "deny";
+    proc_setgroups_write(child, deny.c_str());
+    snprintf(map_path, PATH_MAX, "/proc/%d/gid_map", child);
+    snprintf(map_buf, MAP_BUF_SIZE, "0 %ld 1", (long)gid);
+    gid_map = map_buf;
+    update_map(gid_map, map_path);
+  }
+
+  return child;
+}
+
+static int _dettrace_child(const CloneArgs* clone_args) {
+  if (!clone_args || !clone_args->opts) {
+    return 1;
+  }
+
+  auto opts = clone_args->opts;
+
+  // Properly set up propagation rules for mounts created by dettrace, that is
+  // make this a slave mount (and all mounts underneath this one) so that
+  // changes inside this mount are not propegated to the parent mount. This
+  // makes sure we don't pollute the host OS' mount space with entries made by
+  // us here.
+  if ((opts->clone_ns_flags & CLONE_NEWNS) &&
+      (opts->clone_ns_flags & CLONE_NEWUSER)) {
+    doWithCheck(
+        mount("none", "/", NULL, MS_SLAVE | MS_REC, 0),
+        "failed to mount / as slave");
+  }
+
+  // TODO assert is bad (does not print buffered log output).
+  // Switch to throw runtime exception.
+  if ((opts->clone_ns_flags & CLONE_NEWPID) == CLONE_NEWPID) {
+    pid_t first_pid;
+    if ((first_pid = getpid()) != 1) {
+      std::string errmsg("PID of first process expected to be 1, got: ");
+      errmsg += to_string(first_pid);
+      errmsg += "\n";
+      runtimeError(errmsg);
+    }
+  }
+
+  int pipefds[2];
+
+  doWithCheck(pipe2(pipefds, O_CLOEXEC), "spawnTracerTracee pipe2 failed");
+
+  auto tmpdir = std::make_unique<TempDir>("dt-");
+
+  std::string devrandFifoPath;
+  std::string devUrandFifoPath;
+
+  // DEVRAND STEP 1: create unique /dev/[u]random fifos before we fork, so
+  // that their names are available to tracee
+  {
+    TempPath tmpnamBuffer(*tmpdir);
+    devrandFifoPath = tmpnamBuffer.path() + "-random.fifo";
+    devUrandFifoPath = tmpnamBuffer.path() + "-urandom.fifo";
+  }
+
+  doWithCheck(mkfifo(devrandFifoPath.c_str(), 0666), "mkfifo");
+  doWithCheck(mkfifo(devUrandFifoPath.c_str(), 0666), "mkfifo");
+
+  pid_t pid = fork();
+  if (pid < 0) {
+    runtimeError("fork() failed.\n");
+    exit(EXIT_FAILURE);
+  } else if (pid > 0) {
+    // We must mount proc so that the tracer sees the same PID and /proc/
+    // directory as the tracee. The tracee will do the same so it sees /proc/
+    // under it's chroot.
+    if ((opts->clone_ns_flags & CLONE_NEWNS) == CLONE_NEWNS &&
+        (opts->clone_ns_flags & CLONE_NEWPID) == CLONE_NEWPID) {
+      doWithCheck(
+          mount("none", "/proc/", "proc", MS_MGC_VAL, nullptr),
+          "tracer mounting proc failed");
+    }
+
+    if ((opts->clone_ns_flags & CLONE_NEWNS) == CLONE_NEWNS) {
+      doWithCheck(
+          mount(
+              "none", "/dev/pts", "devpts", MS_MGC_VAL,
+              "newinstance,ptmxmode=0666"),
+          "tracer mounting devpts failed");
+      mountDir("/dev/ptmx", "/dev/pts/ptmx");
+    }
+
+    if (!fileExists(devrandFifoPath)) {
+      runtimeError("cannot create psudo /dev/random fifo");
+    }
+
+    if (!fileExists(devUrandFifoPath)) {
+      runtimeError("cannot create psudo /dev/urandom fifo");
+    }
+
+    // Make the threads for /dev/random and /dev/urandom. We change the seed
+    // such that they output different numbers as one would expect.
+    auto dev_random =
+        RandThread{devrandFifoPath,
+                   static_cast<unsigned short>(opts->prng_seed + 1234567890)};
+    auto dev_urandom =
+        RandThread{devUrandFifoPath,
+                   static_cast<unsigned short>(opts->prng_seed + 234567890)};
+
+    // allow tracee to unblock. it maybe dangerous if tracee runs too early,
+    // when devrandPthread and/or devUrandPthread is not ready: the tracee could
+    // have exited before the pthreads are created, hence the FifoPath might
+    // have be deleted by the tracee already.
+    int ready = 1;
+    doWithCheck(
+        write(pipefds[1], (const void*)&ready, sizeof(int)),
+        "spawnTracerTracee, pipe write");
+
+    const char* log_file = opts->log_file ? opts->log_file : "";
+
+    execution exe{opts->debug_level,
+                  pid,
+                  opts->use_color,
+                  log_file,
+                  opts->print_statistics,
+                  clone_args->vdso_syms,
+                  opts->prng_seed,
+                  opts->allow_network,
+                  logical_clock::from_time_t(opts->epoch),
+                  chrono::microseconds(opts->clock_step),
+                  opts->sys_enter,
+                  opts->sys_exit,
+                  opts->user_data};
+
+    globalExeObject = &exe;
+    struct sigaction sa;
+    sa.sa_handler = sigalrmHandler;
+    doWithCheck(sigemptyset(&sa.sa_mask), "sigemptyset");
+    sa.sa_flags = 0;
+    doWithCheck(sigaction(SIGALRM, &sa, NULL), "sigaction(SIGALRM)");
+    alarm(opts->timeout);
+
+    int exit_code = exe.runProgram();
+
+    // Clean up
+    dev_random.shutdown();
+    dev_urandom.shutdown();
+
+    for (int fd = 3; fd < 256; fd++) {
+      // Close all file descriptors
+      close(fd);
+    }
+
+    umount("/tmp");
+
+    unlink(devrandFifoPath.c_str());
+    unlink(devUrandFifoPath.c_str());
+
+    auto path = tmpdir->path();
+    unlink(path.c_str());
+
+    return exit_code;
+  } else if (pid == 0) {
+    int ready = 0;
+    doWithCheck(
+        read(pipefds[0], &ready, sizeof(int)), "spawnTracerTracee, pipe read");
+    assert(ready == 1);
+    return runTracee(*opts, devrandFifoPath, devUrandFifoPath);
+  }
+
+  return -1;
+}
+
+// This function runs in the child (i.e., the tracee).
+static int runTracee(
+    const TraceOptions& opts,
+    const std::string& devrandFifoPath,
+    const std::string& devUrandFifoPath) {
+  if (!opts.with_aslr) {
+    // Disable ASLR for our child
+    doWithCheck(
+        personality(PER_LINUX | ADDR_NO_RANDOMIZE), "Unable to disable ASLR");
+  }
+
+  if (opts.mount.chroot_dir &&
+      (opts.clone_ns_flags & CLONE_NEWNS) == CLONE_NEWNS) {
+    const auto pathToChroot = std::string{opts.mount.chroot_dir};
+
+    if (!fileExists("/dev/null")) {
+      // we're running under reprotest as sudo, so we can use real mknod
+      // hat tip to:
+      // https://unix.stackexchange.com/questions/27279/how-to-create-dev-null
+      dev_t dev = makedev(1, 3);
+      mode_t mode =
+          S_IFCHR | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+      doWithCheck(mknod("/dev/null", mode, dev), "mknod");
+    }
+
+    if (opts.mount.with_devrand_overrides) {
+      createFileIfNotExist("/dev/random");
+      mountDir(devrandFifoPath, "/dev/random");
+      createFileIfNotExist("/dev/urandom");
+      mountDir(devUrandFifoPath, "/dev/urandom");
+    }
+
+    if (opts.mount.with_proc_overrides) {
+      mountDir(pathToChroot + "/proc/meminfo", "/proc/meminfo");
+      mountDir(pathToChroot + "/proc/stat", "/proc/stat");
+      mountDir(pathToChroot + "/proc/filesystems", "/proc/filesystems");
+    }
+
+    if (opts.mount.with_etc_overrides) {
+      mountDir(pathToChroot + "/etc/hosts", "/etc/hosts");
+      mountDir(pathToChroot + "/etc/passwd", "/etc/passwd");
+      mountDir(pathToChroot + "/etc/group", "/etc/group");
+      mountDir(pathToChroot + "/etc/ld.so.cache", "/etc/ld.so.cache");
+    }
+
+    // for (auto v : args->volume) {
+    //  mountDir(v.source, v.target);
+    //}
+
+    // this have to be done before mount /dev/{u}random because the source file
+    // is under previous /tmp
+    doWithCheck(
+        mount("none", "/tmp", "tmpfs", 0, NULL), "mount /tmp as tmpfs failed");
+  }
+
+  // set working dir
+  if (opts.workdir) {
+    doWithCheck(
+        chdir(opts.workdir), std::string{"unable to chdir to "} + opts.workdir);
+  }
+
+  // trap on rdtsc/rdtscp insns
+  doWithCheck(
+      prctl(PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0), "Pre-clone prctl error");
+  doWithCheck(
+      prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0),
+      "Pre-clone prctl error: setting no new privs");
+
+  // Perform execve based on user command.
+  ptracer::doPtrace(PTRACE_TRACEME, 0, NULL, NULL);
+
+  // Set up seccomp + bpf filters using libseccomp.
+  // Default action to take when no rule applies to system call. We send a
+  // PTRACE_SECCOMP event message to the tracer with a unique data: INT16_MAX
+  seccomp myFilter{opts.debug_level, opts.convert_uids};
+
+  // Stop ourselves until the tracer is ready. This ensures the tracer has time
+  // to get set up.
+  raise(SIGSTOP);
+
+  myFilter.loadFilterToKernel();
+
+  // execvpe() duplicates the actions of the shell in searching for an
+  // executable file if the specified filename does not contain a slash (/)
+  // character.
+  int val = execvpe(opts.program, opts.argv, opts.envs);
+  if (val == -1) {
+    if (errno == ENOENT) {
+      cerr << "Unable to exec your program (" << opts.program
+           << "). No such executable found\n"
+           << endl;
+      cerr << "This program may not exist inside the chroot." << endl;
+      cerr << "Only programs in bin/ or in this directory tree are mounted."
+           << endl;
+    }
+    cerr << "Unable to exec your program. Reason:\n  "
+         << std::string{strerror(errno)} << endl;
+    cerr << "Ending tracer with SIGABTR signal." << endl;
+
+    // Parent is waiting for us to exec so it can trace traceeCommand, this
+    // isn't going to happen. End parent with signal.
+    pid_t ppid = getppid();
+    syscall(SYS_tgkill, ppid, ppid, SIGABRT);
+  }
+
+  return 0;
+}
+
+static void update_map(char* mapping, char* map_file) {
+  int fd = open(map_file, O_WRONLY);
+  if (fd == -1) {
+    fprintf(stderr, "ERROR: open %s: %s\n", map_file, strerror(errno));
+    exit(EXIT_FAILURE);
+  }
+  ssize_t map_len = strlen(mapping);
+  if (write(fd, mapping, map_len) != map_len) {
+    fprintf(stderr, "ERROR: write %s: %s\n", map_file, strerror(errno));
+    exit(EXIT_FAILURE);
+  }
+
+  close(fd);
+}
+// =======================================================================================
+/* Linux 3.19 made a change in the handling of setgroups(2) and the
+   'gid_map' file to address a security issue. The issue allowed
+   *unprivileged* users to employ user namespaces in order to drop
+   The upshot of the 3.19 changes is that in order to update the
+   'gid_maps' file, use of the setgroups() system call in this
+   user namespace must first be disabled by writing "deny" to one of
+   the /proc/PID/setgroups files for this namespace.  That is the
+   purpose of the following function. */
+static void proc_setgroups_write(pid_t pid, const char* str) {
+  char setgroups_path[PATH_MAX];
+  int fd;
+
+  snprintf(setgroups_path, PATH_MAX, "/proc/%d/setgroups", pid);
+
+  fd = open(setgroups_path, O_WRONLY);
+  if (fd == -1) {
+    /* We may be on a system that doesn't support
+       /proc/PID/setgroups. In that case, the file won't exist,
+       and the system won't impose the restrictions that Linux 3.19
+       added. That's fine: we don't need to do anything in order
+       to permit 'gid_map' to be updated.
+       However, if the error from open() was something other than
+       the ENOENT error that is expected for that case,  let the
+       user know. */
+
+    if (errno != ENOENT)
+      fprintf(stderr, "ERROR: open %s: %s\n", setgroups_path, strerror(errno));
+    return;
+  }
+
+  if (write(fd, str, strlen(str)) == -1)
+    fprintf(stderr, "ERROR: write %s: %s\n", setgroups_path, strerror(errno));
+
+  close(fd);
+}

--- a/src/devrand.cpp
+++ b/src/devrand.cpp
@@ -1,0 +1,98 @@
+#include <iostream>
+#include <string>
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "PRNG.hpp"
+#include "devrand.hpp"
+#include "util.hpp"
+
+RandThread::RandThread(const std::string& fifo, unsigned short seed)
+    : fifo{fifo},
+      seed(seed),
+      thread_mutex(PTHREAD_MUTEX_INITIALIZER),
+      thread_ready(PTHREAD_COND_INITIALIZER) {
+  // NB: we copy *FifoPath to the heap as our stack storage goes away: these
+  // allocations DO get leaked If we wanted to not leak them, devRandThread
+  // could copy to its stack and free the heap copy
+  pthread_mutex_lock(&thread_mutex);
+  doWithCheck(
+      pthread_create(&thread, NULL, runThread, this),
+      "pthread_create /dev/random pthread");
+  pthread_cond_wait(&thread_ready, &thread_mutex);
+  // we should unlock then lock the mutex again, but just leave the mutex
+  // locked assuming: unlock -> lock = ID?
+  pthread_mutex_unlock(&thread_mutex);
+  pthread_mutex_destroy(&thread_mutex);
+}
+
+void RandThread::shutdown() {
+  // We should check the return value, but we shouldn't throw exceptions in a
+  // destructor.
+  pthread_cancel(thread);
+}
+
+/**
+ * Thread that writes pseudorandom output to a /dev/[u]random fifo.
+ */
+void* RandThread::runThread(void* data_) {
+  RandThread* t = (RandThread*)data_;
+
+  pthread_mutex_lock(&t->thread_mutex);
+
+  // allow this thread to be unilaterally killed when tracer exits
+  int oldCancelType;
+  doWithCheck(
+      pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldCancelType),
+      "pthread_setcanceltype");
+
+  // fprintf(stderr, "[devRandThread] using fifo  %s, seed: %x\n", fifo,
+  // param->seed);
+
+  PRNG prng(t->seed);
+
+  uint32_t totalBytesWritten = 0;
+  uint16_t random = 0;
+  bool getNewRandom = true;
+
+  // NB: if the fifo is ever closed by all readers/writers, then contents
+  // buffered within it get dropped. This leads to nondeterministic results, so
+  // we always keep the fifo open here. We open the fifo for writing AND reading
+  // as that eliminates EPIPE ("other end of pipe closed") errors when the
+  // tracee has closed the fifo and we call write(). Instead, our write() call
+  // will block once the fifo fills up. Once a tracee starts reading, the buffer
+  // will drain and our write() will get unblocked. However, no bytes should get
+  // lost during this process, ensuring the tracee(s) always see(s) a
+  // deterministic sequence of reads.
+  int fd = open(t->fifo.c_str(), O_RDWR);
+  doWithCheck(fd, std::string("open: ") + t->fifo);
+  pthread_cond_signal(&t->thread_ready);
+  pthread_mutex_unlock(&t->thread_mutex);
+
+  while (true) {
+    if (getNewRandom) {
+      random = prng.get();
+    }
+    int bytesWritten = write(fd, &random, 2);
+    if (2 != bytesWritten) {
+      perror("[devRandThread] error writing to fifo");
+      // need to try writing these bytes again so that the fifo generates
+      // deterministic output
+      getNewRandom = false;
+
+    } else {
+      fsync(fd);
+      getNewRandom = true;
+      totalBytesWritten += 2;
+      // printf("[devRandThread] wrote %u bytes so far...\n",
+      // totalBytesWritten);
+    }
+  }
+
+  close(fd);
+  return NULL;
+}

--- a/src/ptracer.cpp
+++ b/src/ptracer.cpp
@@ -152,8 +152,8 @@ long ptracer::doPtrace(
     }
   } else if (-1 == val) {
     runtimeError(
-        "Ptrace failed with error: " + string{strerror(errno)} + "on thread " +
-        to_string(pid) + " " + " with request " + to_string(request) + "\n");
+        "Ptrace failed with error: " + string{strerror(errno)} + " on thread " +
+        to_string(pid) + " with request " + to_string(request) + "\n");
   }
   return val;
 }

--- a/src/rnr_loader.cpp
+++ b/src/rnr_loader.cpp
@@ -1,11 +1,8 @@
-#include <dlfcn.h>
 #include <sys/types.h>
 
 #include "rnr_loader.hpp"
 #include "util.hpp"
 #include "utilSystemCalls.hpp"
-
-using namespace std;
 
 // TODO: Currently passing PID into prehook and posthook for both PID and TIG
 // arguments. Fix this.
@@ -15,44 +12,9 @@ static bool isNoop = false;
 static int noopSyscall = -1;
 static long noopRetval = -1;
 
-extern "C" {
-static long rnr_nop_sysenter(
-    struct SyscallState* s,
-    int pid,
-    int tid,
-    int syscallno,
-    unsigned long arg0,
-    unsigned long arg1,
-    unsigned long arg2,
-    unsigned long arg3,
-    unsigned long arg4,
-    unsigned long arg5) {
-  return -ENOSYS;
-}
-
-static long rnr_nop_sysexit(
-    struct SyscallState* s,
-    int pid,
-    int tid,
-    int syscallno,
-    unsigned long retval,
-    unsigned long arg0,
-    unsigned long arg1,
-    unsigned long arg2,
-    unsigned long arg3,
-    unsigned long arg4,
-    unsigned long arg5) {
-  return 0;
-}
-}
-
-/* override by `--rnr` command line flag */
-static rnr_loader __rnr__ = {
-    .rnr_sysenter = rnr_nop_sysenter,
-    .rnr_sysexit = rnr_nop_sysexit,
-};
-
 bool rnr::callPreHook(
+    void* user_data,
+    SysEnter sysenter,
     int syscallNumber,
     globalState& gs,
     state& s,
@@ -61,11 +23,10 @@ bool rnr::callPreHook(
   struct SyscallState syscallState;
   syscallState.noop = false;
   auto regs = t.getRegs();
-  auto sysenter = __rnr__.rnr_sysenter;
 
   long prehook_retval = sysenter(
-      &syscallState, s.traceePid, s.traceePid, syscallNumber, regs.rdi,
-      regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9);
+      user_data, &syscallState, s.traceePid, s.traceePid, syscallNumber,
+      regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9);
   // If fingerprinter indicates that the syscall shouldn't be run,
   // cancel the syscall and set the return value
   if (syscallState.noop) {
@@ -80,6 +41,8 @@ bool rnr::callPreHook(
 }
 
 void rnr::callPostHook(
+    void* user_data,
+    SysExit sysexit,
     int syscallNumber,
     globalState& gs,
     state& s,
@@ -93,29 +56,7 @@ void rnr::callPostHook(
     isNoop = false;
   }
   auto regs = t.getRegs();
-  auto sysexit = __rnr__.rnr_sysexit;
   sysexit(
-      &syscallState, s.traceePid, s.traceePid, regs.orig_rax, (long)regs.rax,
-      regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9);
-}
-
-/* must be called early, no lock is provied */
-void rnr::loadRnr(const string& dso) {
-  void* handle = dlopen(dso.c_str(), RTLD_NOW);
-
-  auto sysenter = dlsym(handle, "rnr_sysenter");
-  if (!sysenter) {
-    runtimeError("could not find rnr_sysenter");
-  }
-  auto sysexit = dlsym(handle, "rnr_sysexit");
-  if (!sysexit) {
-    runtimeError("could not find rnr_sysexit");
-  }
-
-  __rnr__.rnr_sysenter = reinterpret_cast<decltype(rnr_nop_sysenter)*>(
-      reinterpret_cast<unsigned long>(sysenter));
-  __rnr__.rnr_sysexit = reinterpret_cast<decltype(rnr_nop_sysexit)*>(
-      reinterpret_cast<unsigned long>(sysexit));
-
-  // NB: no dlclose to keep keep the symbols intact.
+      user_data, &syscallState, s.traceePid, s.traceePid, regs.orig_rax,
+      (long)regs.rax, regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9);
 }

--- a/src/vdso.cpp
+++ b/src/vdso.cpp
@@ -162,6 +162,7 @@ std::vector<ProcMapEntry> parseProcMapEntries(pid_t pid) {
 
   fd = open(mapsFile, O_RDONLY);
   if (fd < 0) {
+    perror("Failed to open /proc/self/maps");
     return {};
   }
 
@@ -228,10 +229,8 @@ std::vector<std::string> vdsoGetFuncNames(void) {
  * return as std::tuple<symbol_address, symbol_size, symbol/section_alignment>
  * NB: symbol address is relative (just an offset).
  */
-std::map<std::string, std::tuple<unsigned long, unsigned long, unsigned long>>
-vdsoGetSymbols(pid_t pid) {
-  std::map<std::string, std::tuple<unsigned long, unsigned long, unsigned long>>
-      res;
+VDSOSymbols vdsoGetSymbols(pid_t pid) {
+  VDSOSymbols res;
   struct ProcMapEntry vdsoMapEntry;
 
   if (vdsoGetMapEntry(pid, vdsoMapEntry) != 0) {
@@ -263,7 +262,7 @@ vdsoGetSymbols(pid_t pid) {
       unsigned long alignment = sym->st_shndx < ehdr->e_shnum
                                     ? shbase[sym->st_shndx].sh_addralign
                                     : 16;
-      res[name] = std::tie(sym->st_value, sym->st_size, alignment);
+      res[name] = VDSOSymbol{sym->st_value, sym->st_size, alignment};
     }
   }
 


### PR DESCRIPTION
This splits dettrace up so that it can be run via a C function call. This makes it easier to pass callback functions to dettrace for execution upon each system call. Loading a .so library is rather clunky, so that has been removed.

The spawning of threads for `/dev/[u]random` has also been opportunistically refactored such that it no longer requires global static variables.