### PR TITLE
Call rnr posthook before dettrace poosthook

### DIFF
--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -253,13 +253,13 @@ void execution::handlePostSystemCall(state& currState) {
         tracer.getReturnValue());
   }
 
-  callPostHook(syscallNum, myGlobalState, currState, tracer, myScheduler);
   if (sys_exit_hook && syscallNum != SYS_arch_prctl) {
     rnr::callPostHook(
         user_data, sys_exit_hook, syscallNum, myGlobalState, currState, tracer,
         myScheduler);
   }
 
+  callPostHook(syscallNum, myGlobalState, currState, tracer, myScheduler);
   log.writeToLog(
       Importance::info, "Value after handler: %d\n", tracer.getReturnValue());
 


### PR DESCRIPTION
dettrace posthook can do replaySystemCall, which changes %rax
If we call rnr posthook after, it confuses rnr posthook because
it is expecting %rax holds the return value from the system call.

Unfortunately we cannot simply re-use %rax because it is also used
as syscall number register. dettrace replaySystemCall expects the
syscall to be restarted hence %rax must hold the original syscall
number.