### PR TITLE
Squash warnings in samplePrograms.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017-2019
+Copyright 2017-2020
 
 This work is a product of joint-authorship, with source files herein
 owned by the below contributors, unless otherwise specified in a file
@@ -10,10 +10,15 @@ or subdirectory of this DetTrace repository.
    - Kelly Renee Shiptoski <kelly.shiptoski@gmail.com>
  * Cloudseal Inc, via contributions of:
    - Omar Navarro Leija <gatoWololo@gmail.com>
+   - Jason White <github@jasonwhite.io>
    - Joseph Devietti <joe@devietti.net>
    - Kelly Renee Shiptoski <kelly.shiptoski@gmail.com>
    - Ryan Glenn Scott <ryan.gl.scott@gmail.com>
    - Ryan Rhodes Newton <rrnewton@gmail.com>
+ * Facebook, Inc. and its affiliates. Based on contributions of:
+   - Baojun Wang <wangbj@fb.com>
+   - Jason White <jasonwhite@fb.com>
+   - Ryan Rhodes Newton <newton@fb.com>   
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/test/samplePrograms/Makefile
+++ b/test/samplePrograms/Makefile
@@ -44,18 +44,18 @@ test-scripts: $(patsubst %.sh, %.ok, $(SHELL_SCRIPTS))
 
 # compile each sample program binary
 $(SIMPLE_BINARIES): %.bin: %.c
-	@$(CC) $< -Wall -g -o $@ -pthread -std=gnu99
+	@$(CC) $< -Wall -Werror -g -o $@ -pthread -std=gnu99
 
 # HW RNG tests need >=broadwell codegen
 $(BROADWELL_BINARIES): %.bin: %.c
-	@$(CC) $< -Wall -g -o $@ -pthread -std=gnu99 -march=broadwell
+	@$(CC) $< -Wall -Werror -g -o $@ -pthread -std=gnu99 -march=broadwell
 
 # timer_create tests need to link with -lrt
 $(RT_BINARIES): %.bin: %.c
-	@$(CC) $< -Wall -g -o $@ -std=gnu99 -lrt
+	@$(CC) $< -Wall -Werror -g -o $@ -std=gnu99 -lrt
 
 $(CXX_BINARIES): %.bin: %.cpp
-	@$(CXX) $< -Wall -g -o $@ -std=gnu++11
+	@$(CXX) $< -Wall -Werror -g -o $@ -std=gnu++11
 
 rdinsn.ok: rdinsn.bin
 	@echo "   Testing rdrand..."

--- a/test/samplePrograms/alarm-handler.c
+++ b/test/samplePrograms/alarm-handler.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <stdlib.h>
 #include <stdbool.h>

--- a/test/samplePrograms/execveMainThread.c
+++ b/test/samplePrograms/execveMainThread.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 #include <sched.h>
 #include <errno.h>
 #include <stdio.h>

--- a/test/samplePrograms/execveThreads.c
+++ b/test/samplePrograms/execveThreads.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 #include <sched.h>
 #include <errno.h>
 #include <stdio.h>

--- a/test/samplePrograms/exitgroup.c
+++ b/test/samplePrograms/exitgroup.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 #include <sched.h>
 #include <errno.h>
 #include <stdio.h>
@@ -21,14 +21,14 @@ int pipefd[2];
 // Process spawns thread with clone().
 // Thread blocks trying to read from a pipe.
 // Can the process still exit?
-int thread_func(void *arg){
+void* thread_func(void *arg){
   printf("Thread wants to read from pipe.\n");
   char buf[bytesToRead];
-  int bytes = read(pipefd[0], buf, bytesToRead);
-  return 0;
+  read(pipefd[0], buf, bytesToRead);
+  return NULL;
 }
 
-int other_func(void *arg){
+void* other_func(void *arg){
   printf("Special thread triggering exit_group.\n");
     _exit(EXIT_SUCCESS);
 }
@@ -44,20 +44,22 @@ int main(void){
   }
 
   pthread_t threads[10];
-  int t[10];
+  // int t[10];
   for(int i = 0; i < 9; i++){
     //void* child_stack = malloc(STACK_SIZE);
     //int thread_pid;
     printf("Creating new thread.\n");
     //thread_pid = clone(thread_func, child_stack+STACK_SIZE, CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, NULL);
-    t[i] = pthread_create(&threads[i], NULL, thread_func, NULL);
+    // t[i] =
+    pthread_create(&threads[i], NULL, thread_func, NULL);
   }
 
   //void* child_stack = malloc(STACK_SIZE);
   //int thread_pid;
   printf("Creating special thread.\n");
   //thread_pid = clone(other_func, child_stack+STACK_SIZE, CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, NULL);
-  t[9] = pthread_create(&threads[9], NULL, other_func, NULL);
+  // t[9] =
+  pthread_create(&threads[9], NULL, other_func, NULL);
   
   for(int i = 0; i < 10; i++){
     pthread_join(threads[i], NULL);

--- a/test/samplePrograms/exitgroupMainProcess.c
+++ b/test/samplePrograms/exitgroupMainProcess.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 #include <sched.h>
 #include <errno.h>
 #include <stdio.h>
@@ -21,11 +20,11 @@ int pipefd[2];
 // Process spawns thread with clone().
 // Thread blocks trying to read from a pipe.
 // Can the process still exit?
-int thread_func(void *arg){
+void* thread_func(void *arg){
   printf("Thread wants to read from pipe.\n");
   char buf[bytesToRead];
-  int bytes = read(pipefd[0], buf, bytesToRead);
-  return 0;
+  read(pipefd[0], buf, bytesToRead);
+  return NULL;
 }
 
 int main(void){
@@ -39,10 +38,9 @@ int main(void){
   }
 
   pthread_t threads[10];
-  int t[10];
   for(int i = 0; i < 10; i++){
     printf("Creating new thread.\n");
-    t[i] = pthread_create(&threads[i], NULL, thread_func, NULL);
+    pthread_create(&threads[i], NULL, thread_func, NULL);
   }
 
   // Give some time for threads to spawn...

--- a/test/samplePrograms/getdents.c
+++ b/test/samplePrograms/getdents.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 #include <dirent.h>     /* Defines DT_* constants */
 #include <fcntl.h>
 #include <stdio.h>

--- a/test/samplePrograms/getdents64.c
+++ b/test/samplePrograms/getdents64.c
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <dirent.h>     /* Defines DT_* constants */
 #include <fcntl.h>
 #include <stdio.h>

--- a/test/samplePrograms/multithreaded.c
+++ b/test/samplePrograms/multithreaded.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 #include <pthread.h>
 #include <sched.h>
 #include <errno.h>
@@ -17,23 +17,23 @@ const int bytesToRead = 100;
 const int bytesToWrite = 100;
 int pipefd[2];
 
-int second_thread(void *arg){
+void* second_thread(void *arg){
   printf("Thread2 trying to write to pipe.\n");
   char buf[bytesToWrite];
   int bytes = write(pipefd[1], buf, bytesToWrite);
   printf("Thread2 wrote this many bytes: %d\n", bytes);
   printf("Thread2 is done.\n");
   fflush(NULL);
-  return 0;
+  return NULL;
 }
 
-int first_thread(void *arg){
+void* first_thread(void *arg){
   char buffer[bytesToRead];
   int b = read(pipefd[0], buffer, bytesToRead);
   printf("Thread1 read this many bytes: %d\n", b);
   printf("Thread1 is done.\n");
   fflush(NULL);
-  return 0;
+  return NULL;
 }
 
 int main(void){
@@ -46,9 +46,9 @@ int main(void){
   printf("Process spawning thread1 with pthread create.\n");
   pthread_t thread1;
   pthread_t thread2;
-  int p = pthread_create(&thread1, NULL, first_thread, NULL);
+  pthread_create(&thread1, NULL, first_thread, NULL);
   printf("Process spawning thread2 with pthread create.\n");
-  int p2 = pthread_create(&thread2, NULL, second_thread, NULL);
+  pthread_create(&thread2, NULL, second_thread, NULL);
   pthread_join(thread1, NULL);
   pthread_join(thread2, NULL);
   

--- a/test/samplePrograms/open_already_exists.c
+++ b/test/samplePrograms/open_already_exists.c
@@ -1,3 +1,6 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -37,8 +40,8 @@ int main(){
   system("rm -f temp.txt");
 
   printf("mtime %ld\n", time);
-  printf("mtime2 %ld\n", time);
-  printf("mtime3 %ld\n", time);
+  printf("mtime2 %ld\n", time2);
+  printf("mtime3 %ld\n", time3);
 
   return 0;
 }

--- a/test/samplePrograms/openat_already_exists.c
+++ b/test/samplePrograms/openat_already_exists.c
@@ -38,8 +38,8 @@ int main(){
   system("rm -f temp.txt");
 
   printf("mtime %ld\n", time);
-  printf("mtime2 %ld\n", time);
-  printf("mtime3 %ld\n", time);
+  printf("mtime2 %ld\n", time2);
+  printf("mtime3 %ld\n", time3);
 
   return 0;
 }

--- a/test/samplePrograms/processAndThread.c
+++ b/test/samplePrograms/processAndThread.c
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <sys/types.h>
 #include <sched.h>
 #include <errno.h>

--- a/test/samplePrograms/processThreadProcess.c
+++ b/test/samplePrograms/processThreadProcess.c
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <sched.h>
 #include <errno.h>
 #include <stdio.h>

--- a/test/samplePrograms/processThreadThread.c
+++ b/test/samplePrograms/processThreadThread.c
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <sched.h>
 #include <errno.h>
 #include <stdio.h>

--- a/test/samplePrograms/pthreadJoin.c
+++ b/test/samplePrograms/pthreadJoin.c
@@ -12,7 +12,7 @@ const int bytesToRead = 100;
 const int bytesToWrite = 100;
 int pipefd[2];
 
-int thread_func(void *arg){
+void* thread_func(void *arg){
   printf("Thread - my pid is: %d\n", getpid());
   printf("Thread - my ppid is: %d\n", getppid());
   printf("Thread wants to read from pipe.\n");

--- a/test/samplePrograms/pthreadNoJoin.c
+++ b/test/samplePrograms/pthreadNoJoin.c
@@ -12,7 +12,7 @@ const int bytesToRead = 100;
 const int bytesToWrite = 100;
 int pipefd[2];
 
-int thread_func(void *arg){
+void* thread_func(void *arg){
   printf("Thread - my pid is: %d\n", getpid());
   printf("Thread - my ppid is: %d\n", getppid());
   printf("Thread wants to read from pipe.\n");

--- a/test/samplePrograms/ptpThreadJoin.c
+++ b/test/samplePrograms/ptpThreadJoin.c
@@ -16,7 +16,7 @@ const int bytesToRead = 100;
 const int bytesToWrite = 100;
 int pipefd[2];
 
-int thread_func(void *arg){
+void* thread_func(void *arg){
   printf("Thread1 forking P2.\n");
   printf("Thread 1 pid: %d\n", getpid());
   printf("Thread 1 ppid: %d\n", getppid());
@@ -31,7 +31,7 @@ int thread_func(void *arg){
     printf("Child process read this many bytes: %d\n", bytes);
     printf("Child process done.\n");
     printf("Child process parent pid is now: %d\n", getppid());
-    return 0;
+    return NULL;
   }
   
   // Thread writes to pipe.
@@ -53,7 +53,7 @@ int main(void){
   printf("Parent process ppid: %d\n", getppid());
   
   pthread_t thread1;
-  int p = pthread_create(&thread1, NULL, thread_func, NULL);
+  pthread_create(&thread1, NULL, thread_func, NULL);
   printf("Process made thread.\n");
   pthread_join(thread1, NULL);
 

--- a/test/samplePrograms/ptpThreadNoJoin.c
+++ b/test/samplePrograms/ptpThreadNoJoin.c
@@ -16,7 +16,7 @@ const int bytesToRead = 100;
 const int bytesToWrite = 100;
 int pipefd[2];
 
-int thread_func(void *arg){
+void* thread_func(void *arg){
   printf("Thread1 forking P2.\n");
   printf("Thread 1 pid: %d\n", getpid());
   printf("Thread 1 ppid: %d\n", getppid());
@@ -31,7 +31,7 @@ int thread_func(void *arg){
     printf("Child process read this many bytes: %d\n", bytes);
     printf("Child process done.\n");
     printf("Child process parent pid is now: %d\n", getppid());
-    return 0;
+    return NULL;
   }
   
   // Thread writes to pipe.
@@ -53,7 +53,7 @@ int main(void){
   printf("Parent process ppid: %d\n", getppid());
   
   pthread_t thread1;
-  int p = pthread_create(&thread1, NULL, thread_func, NULL);
+  pthread_create(&thread1, NULL, thread_func, NULL);
   printf("Process made thread.\n");
 
   printf("Process is exiting.\n");

--- a/test/samplePrograms/rdinsn.c
+++ b/test/samplePrograms/rdinsn.c
@@ -51,11 +51,12 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  int (*rdinsn)(unsigned long long*);
+  // int (*rdinsn)(unsigned long long*);
   if (0 == strcmp("rdrand",argv[1])) {
-    rdinsn = rdrand;
+    // rdinsn = rdrand;
   } else if (0 == strcmp("rdseed",argv[1])) {
-    rdinsn = rdseed;
+    // UNFINISHED!
+    // rdinsn = rdseed;
   } else {
     printUsage(argv[0]);
     return 1;

--- a/test/samplePrograms/setitimer-prof.c
+++ b/test/samplePrograms/setitimer-prof.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <stdlib.h>
 #include <stdbool.h>

--- a/test/samplePrograms/setitimer-real.c
+++ b/test/samplePrograms/setitimer-real.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <stdlib.h>
 #include <stdbool.h>

--- a/test/samplePrograms/setitimer-virtual.c
+++ b/test/samplePrograms/setitimer-virtual.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <stdlib.h>
 #include <stdbool.h>

--- a/test/samplePrograms/setitimer.c
+++ b/test/samplePrograms/setitimer.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <stdlib.h>
 #include <stdbool.h>

--- a/test/samplePrograms/sigabrt.c
+++ b/test/samplePrograms/sigabrt.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <signal.h>
 #include <stdio.h>

--- a/test/samplePrograms/sigill.c
+++ b/test/samplePrograms/sigill.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <signal.h>
 #include <stdio.h>

--- a/test/samplePrograms/sigsegv.c
+++ b/test/samplePrograms/sigsegv.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <signal.h>
 #include <stdio.h>

--- a/test/samplePrograms/simple_mkdirat_dirfd.c
+++ b/test/samplePrograms/simple_mkdirat_dirfd.c
@@ -22,7 +22,7 @@ int main(){
   struct stat myStat;
   withError(stat(file, &myStat), "stat");
   time_t mtime = myStat.st_mtime;
-  ino_t inode = myStat.st_ino;
+  // ino_t inode = myStat.st_ino;
 
   system("rm -rf "file);
   printf("mtime %ld\n", mtime);

--- a/test/samplePrograms/symlink.c
+++ b/test/samplePrograms/symlink.c
@@ -29,7 +29,7 @@ int main(){
 
   struct stat st;
   withError(lstat(symlink_name, &st), "stat");
-  ino_t inode = st.st_ino;
+  // ino_t inode = st.st_ino;
 
   withError(unlink(symlink_target), "Unlink "symlink_target);
   withError(unlink(symlink_name), "Unlink symlink");

--- a/test/samplePrograms/symlinkat.c
+++ b/test/samplePrograms/symlinkat.c
@@ -30,7 +30,7 @@ int main(){
 
   struct stat st;
   withError(lstat(symlink_name, &st), "stat");
-  ino_t inode = st.st_ino;
+  // ino_t inode = st.st_ino;
 
   withError(unlink(symlink_target), "Unlink "symlink_target);
   withError(unlink(symlink_name), "Unlink symlink");

--- a/test/samplePrograms/tenThreadJoin.c
+++ b/test/samplePrograms/tenThreadJoin.c
@@ -5,7 +5,7 @@
 #include <unistd.h>
 
 // TODO: Thread function.
-void thread_func(void *arg){
+void* thread_func(void *arg){
   printf("Thread's pid: %d\n", getpid());
   printf("Thread's ppid: %d\n", getppid());
   pthread_exit(NULL);

--- a/test/samplePrograms/tenThreadNoJoin.c
+++ b/test/samplePrograms/tenThreadNoJoin.c
@@ -5,7 +5,7 @@
 #include <unistd.h>
 
 // TODO: Thread function.
-void thread_func(void *arg){
+void* thread_func(void *arg){
   printf("Thread's pid: %d\n", getpid());
   printf("Thread's ppid: %d\n", getppid());
   pthread_exit(NULL);

--- a/test/samplePrograms/tgkill.c
+++ b/test/samplePrograms/tgkill.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/syscall.h>

--- a/test/samplePrograms/timer_create_default.c
+++ b/test/samplePrograms/timer_create_default.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <stdlib.h>
 #include <signal.h>

--- a/test/samplePrograms/timer_create_sigvtalrm.c
+++ b/test/samplePrograms/timer_create_sigvtalrm.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <stdlib.h>
 #include <signal.h>

--- a/test/samplePrograms/timer_gettime.c
+++ b/test/samplePrograms/timer_gettime.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 
 #include <stdlib.h>
 #include <signal.h>

--- a/test/samplePrograms/twoPthreadsJoin.c
+++ b/test/samplePrograms/twoPthreadsJoin.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 #include <pthread.h>
 #include <sched.h>
 #include <errno.h>
@@ -19,7 +19,7 @@ const int bytesToRead = 100;
 const int bytesToWrite = 100;
 int pipefd[2];
 
-int second_thread(void *arg){
+void* second_thread(void *arg){
   printf("Thread 2 pid: %d\n", getpid());
   printf("Thread2 trying to read from pipe.\n");
   char buf[bytesToRead];
@@ -27,14 +27,14 @@ int second_thread(void *arg){
   printf("Thread2 read this many bytes: %d\n", bytes);
   printf("Thread2 is done.\n");
   fflush(NULL);
-  return 0;
+  return NULL;
 }
 
-int first_thread(void *arg){
+void* first_thread(void *arg){
   printf("Thread 1 pid: %d\n", getpid());
   printf("Thread1 spawning thread2 with pthread create.\n");
   pthread_t thread2;
-  int p = pthread_create(&thread2, NULL, second_thread, NULL);
+  pthread_create(&thread2, NULL, second_thread, NULL);
   printf("Thread1 made thread2.\n");
 
   char buffer[bytesToWrite];
@@ -43,7 +43,7 @@ int first_thread(void *arg){
   printf("Thread1 is done.\n");
   fflush(NULL);
   pthread_join(thread2, NULL);
-  return 0;
+  return NULL;
 }
 
 int main(void){
@@ -55,7 +55,7 @@ int main(void){
 
   printf("Process spawning thread1 with pthread create.\n");
   pthread_t thread1;
-  int p = pthread_create(&thread1, NULL, first_thread, NULL);
+  pthread_create(&thread1, NULL, first_thread, NULL);
   printf("Process made thread1.\n");
   pthread_join(thread1, NULL);
   

--- a/test/samplePrograms/twoPthreadsNoJoin.c
+++ b/test/samplePrograms/twoPthreadsNoJoin.c
@@ -1,4 +1,4 @@
-#define _GNU_SOURCE
+
 #include <pthread.h>
 #include <sched.h>
 #include <errno.h>
@@ -19,20 +19,20 @@ const int bytesToRead = 100;
 const int bytesToWrite = 100;
 int pipefd[2];
 
-int second_thread(void *arg){
+void* second_thread(void *arg){
   printf("Thread2 trying to read from pipe.\n");
   char buf[bytesToRead];
   int bytes = read(pipefd[0], buf, bytesToRead);
   printf("Thread2 read this many bytes: %d\n", bytes);
   printf("Thread2 is done.\n");
   fflush(NULL);
-  return 0;
+  return NULL;
 }
 
-int first_thread(void *arg){
+void* first_thread(void *arg){
   printf("Thread1 spawning thread2 with pthread create.\n");
   pthread_t thread2;
-  int p = pthread_create(&thread2, NULL, second_thread, NULL);
+  pthread_create(&thread2, NULL, second_thread, NULL);
   printf("Thread1 made thread2.\n");
 
   char buffer[bytesToWrite];
@@ -40,7 +40,7 @@ int first_thread(void *arg){
   printf("Thread1 wrote this many bytes: %d\n", b);
   printf("Thread1 is done.\n");
   fflush(NULL);
-  return 0;
+  return NULL;
 }
 
 int main(void){
@@ -52,7 +52,7 @@ int main(void){
 
   printf("Process spawning thread1 with pthread create.\n");
   pthread_t thread1;
-  int p = pthread_create(&thread1, NULL, first_thread, NULL);
+  pthread_create(&thread1, NULL, first_thread, NULL);
   printf("Process made thread1.\n");
   
   printf("Process is exiting.\n");


### PR DESCRIPTION
Change warnings to errors.
Also, remove unneccessary GNU_SOURCE defs, and wrap necessary ones with ifndef.

This allows the samplePrograms to build in stricter environments that brook no nonsense.
