### PR TITLE
Add missing seccomp functions

### DIFF
--- a/src/seccomp.cpp
+++ b/src/seccomp.cpp
@@ -131,6 +131,8 @@ void seccomp::loadRules(bool debug, bool convertUids) {
   noIntercept(SYS_setresgid);
   noIntercept(SYS_setresuid);
   noIntercept(SYS_setreuid);
+  noIntercept(SYS_setfsgid);
+  noIntercept(SYS_setfsuid);
   noIntercept(SYS_setuid);
   // This seems to be, surprisingly, deterministic. The affinity is set/get by
   // us so it should always be the same mask. User cannot actually observe


### PR DESCRIPTION
this broke dettrace on openSUSE Leap 15.1

Without this patch, it failed thus:
```
 dettrace -- bash -c 'echo $RANDOM;date'
 15216
 Mon Aug  9 00:00:00 CEST 1993
 terminate called after throwing an instance of 'std::runtime_error'
   what():  dettrace runtime exception: No filter rule for system call: setfsuid
```